### PR TITLE
chore: Enable dependabot upgrades, CodeQL scanning, and pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "timoguin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    - cron: '25 4 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - "go"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: go-build
+      - id: go-mod-tidy
+      - id: go-mod-vendor
+      # Enable these later, once a good dependency checker/installer is in the Makefile
+      # and dependencies are defined in the README.
+      #
+      # - id: go-lint
+      # - id: go-imports
+      # - id: go-cyclo
+      # - id: go-critic

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile to help with builds
 #
 
-VERSION      := 0.0.1
+VERSION      := 0.0.2
 GIT_COMMIT   := $(shell git rev-parse HEAD)
 GO_VERSION   := $(shell go version | sed 's/go version //')
 BIN_NAME     := goldap

--- a/cmd/build_info.go
+++ b/cmd/build_info.go
@@ -4,6 +4,5 @@ package cmd
 var (
 	Version   string
 	GitCommit string
-	BuildTime string
 	GoVersion string
 )

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -35,12 +35,12 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Sprintf("Error parsing config file %s: %s", viper.ConfigFileUsed(), err)
+		fmt.Printf("Error parsing config file %s: %s", viper.ConfigFileUsed(), err)
 	}
 
 	// Bind all command flags to Viper config
 	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
-		fmt.Sprintf("Error binding config flags with viper: %s", err)
+		fmt.Printf("Error binding config flags with viper: %s", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/go-ldap/ldap/v3"
@@ -25,7 +26,7 @@ var SearchHelp = map[string]string{
 | to be more readable, while the familiar names from ldapsearch are supported as aliases. |
 | The filter must be passed via the --filter flag, and attributes must be passed via one  |
 | or more --attribute flags.                                                              |
-|                                                                                         |  
+|                                                                                         |
 ===========================================================================================
 
 `,
@@ -132,7 +133,13 @@ func SearchCmdRun(cmd *cobra.Command, args []string) {
 
 	// Reconnect with TLS
 	if viper.GetBool("start-tls") {
-		err = session.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		url, err := url.Parse(ldapURI)
+		if err != nil {
+			Logger.Fatalw("Failed to parse LDAP URI", "err", err)
+			os.Exit(1)
+		}
+
+		err = session.StartTLS(&tls.Config{ServerName: url.Hostname()})
 		if err != nil {
 			Logger.Fatalw("Failed to connect with TLS", "err", err)
 			os.Exit(1)


### PR DESCRIPTION
## Added

- Configuration for dependabot version upgrades
- GitHub Actions workflow for CodeQL analysis
- pre-commit configuration for common use cases and basic Golang checks

## Changed

- Fix incorrect usage of `fmt.Sprintf` instead of `fmt.Printf`

## Removed

- Remove unused `BuildTime` var from `cmd/build_info.go`
